### PR TITLE
Apply environment natively in addition to JVM view - fixes #3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,11 +9,14 @@ description := "An SBT Plugin to load environment variables from .env into the J
 
 organization := "au.com.onegeek"
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.0" % "test"
+libraryDependencies ++= Seq(
+    "net.java.dev.jna" % "jna" % "4.1.0",
+    "org.scalatest" %% "scalatest" % "2.1.0" % "test"
+)
 
 scalaVersion := "2.10.4"
 
-version := "1.0"
+version := "1.1"
 
 publishMavenStyle := false
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.5
+sbt.version = 0.13.7

--- a/src/main/java/au/com/onegeek/sbtdotenv/NativeEnvironmentManager.java
+++ b/src/main/java/au/com/onegeek/sbtdotenv/NativeEnvironmentManager.java
@@ -1,0 +1,93 @@
+package au.com.onegeek.sbtdotenv;
+
+import java.util.Map;
+
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import com.sun.jna.Platform;
+
+/**
+ * Change the actual program environment so that changes propagate to child processes
+ *
+ * Taken from: http://stackoverflow.com/questions/318239/how-do-i-set-environment-variables-from-java/7201825#7201825
+ *
+ * Created by mfellows on 20/07/2014.
+ */
+
+public abstract class NativeEnvironmentManager {
+    public abstract void setEnv(String key, String value);
+
+    public static class EnvironmentException extends RuntimeException {
+        EnvironmentException(String key) {
+            super("Failed to set environment variable: " + key);
+        }
+    }
+
+    static class WindowsNativeEnvironmentManagerImpl extends NativeEnvironmentManager {
+        public static interface WindowsEnvironmentLibC extends Library {
+            WindowsEnvironmentLibC INSTANCE = (
+                (WindowsEnvironmentLibC)Native.loadLibrary("msvcrt",
+                    WindowsEnvironmentLibC.class)
+            );
+
+            int _putenv(String name);
+        }
+
+        private WindowsEnvironmentLibC libc = WindowsEnvironmentLibC.INSTANCE;
+
+        @Override
+        public void setEnv(String name, String value) {
+            String s = name + "=";
+            if(value != null)
+                name += value;
+
+            if(libc._putenv(s) != 0)
+                throw new EnvironmentException(name);
+        }
+    }
+
+    static class PosixNativeEnvironmentManagerImpl extends NativeEnvironmentManager {
+        public static interface PosixEnvironmentLibC extends Library {
+            PosixEnvironmentLibC INSTANCE = (
+                (PosixEnvironmentLibC) Native.loadLibrary("c",
+                    PosixEnvironmentLibC.class)
+            );
+
+            int setenv(String name, String value, int overwrite);
+            int unsetenv(String name);
+        }
+
+        private PosixEnvironmentLibC libc = PosixEnvironmentLibC.INSTANCE;
+
+        @Override
+        public void setEnv(String name, String value) {
+            int result;
+            if (value != null)
+                result = libc.setenv(name, value, 1);
+            else
+                result = libc.unsetenv(name);
+
+            if(result != 0)
+                throw new EnvironmentException(name);
+        }
+    }
+
+    private static NativeEnvironmentManager instance = null;
+    public static NativeEnvironmentManager getInstance() {
+        if(instance == null) {
+            if(Platform.isWindows())
+                instance = new WindowsNativeEnvironmentManagerImpl();
+            else
+                instance = new PosixNativeEnvironmentManagerImpl();
+        }
+
+        return instance;
+    }
+
+    public static void setEnv(Map<String, String> env) {
+        NativeEnvironmentManager envManager = NativeEnvironmentManager.getInstance();
+        for(Map.Entry<String, String> entry : env.entrySet()) {
+            envManager.setEnv(entry.getKey(), entry.getValue());
+        }
+    }
+}

--- a/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
+++ b/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
@@ -65,6 +65,7 @@ object SbtDotenv extends AutoPlugin {
     val dotEnvFile: File = new File(configuration.baseDirectory + "/.env")
     parseFile(dotEnvFile).map { environment =>
       state.log.debug(s".env detected. About to configure JVM System Environment with new map: $environment")
+      NativeEnvironmentManager.setEnv(environment.asJava)
       DirtyEnvironmentHack.setEnv((sys.env ++ environment).asJava)
       state.log.info("Configured .env environment")
     }.getOrElse({


### PR DESCRIPTION
The JVM has it's own special view of environment variables, which was
the only thing changed previously. That does not work, unfortunately, if
any child processes are spawned, which can happen in SBT if new JVMs are
started by forking, or if artifacts are packaged before execution.

To change the native environment we rely on JNA, with two different
implementations, one for Windows and one for POSIX platforms, which
should be good enough coverage. We call the corresponding C library
functions to alter process environment.

Unfortunately, we need to keep the old hack as well since the JVM never
updates its view of the environment after startup.

PS: I have not actually tested this at all on anything but Linux. It should work fine in any existing POSIX platform, but it would be a good idea to test it on Windows separately.