### PR TITLE
trim comment startsWith ' #'(space and hash)

### DIFF
--- a/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
+++ b/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
@@ -108,7 +108,10 @@ object SbtDotenv extends AutoPlugin {
    */
   def parseLine(line: String): Option[(String, String)] = {
     isValidLine(line) match {
-      case true => Some((line.split("=", 2)(0) -> line.split("=", 2)(1)))
+      case true => {
+        val splitted = line.split("=", 2)
+        Some(splitted(0) -> splitted(1).split(" #")(0).trim)
+      }
       case false => None
     }
   }

--- a/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
+++ b/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
@@ -77,6 +77,12 @@ class SbtDotenvSpec extends WordSpec  with Matchers   {
 
         SbtDotenv.isValidLine("") should equal(false)
         SbtDotenv.parseLine("") should equal(None)
+
+        SbtDotenv.isValidLine("WITHOUT_COMMENT=ThisIsValue # here is a comment") should equal (true)
+        SbtDotenv.parseLine("WITHOUT_COMMENT=ThisIsValue # here is a comment") should equal (Some("WITHOUT_COMMENT", "ThisIsValue"))
+
+        SbtDotenv.isValidLine("WITH_HASH_URL=http://example.com#awesome-id") should equal (true)
+        SbtDotenv.parseLine("WITH_HASH_URL=http://example.com#awesome-id") should equal (Some("WITH_HASH_URL", "http://example.com#awesome-id"))
       }
 
       "Provide a SBT CLI warning if file contents invalid" in {


### PR DESCRIPTION
This PR supports comment syntax like SHELL, also URL with anchor.

Comment syntax is below.

```bash
bash-4.3$ WITHOUT_COMMENT=ThisIsValue # here is a comment
bash-4.3$ echo $WITHOUT_COMMENT
ThisIsValue
```