### PR TITLE
Allow dot character as valid part of environment variable names.

### DIFF
--- a/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
+++ b/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
@@ -88,7 +88,7 @@ object SbtDotenv extends AutoPlugin {
     }
   }
 
-  def isValidLine(line: String): Boolean = line.matches("^[a-zA-Z_]+[a-zA-Z0-9_]*=.*")
+  def isValidLine(line: String): Boolean = line.matches("^[a-zA-Z_]+[a-zA-Z0-9_\\.]*=.*")
 
   /**
    * Extract k/v pairs from each line as an environment Key -> Value.

--- a/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
+++ b/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
@@ -51,8 +51,11 @@ class SbtDotenvSpec extends WordSpec with Matchers {
       SbtDotenv.isValidLine("FOO=1234") should equal(true)
       SbtDotenv.parseLine("FOO=1234") should equal(Some("FOO", "1234"))
 
-      SbtDotenv.isValidLine("F.OO=bar") should equal(false)
-      SbtDotenv.parseLine("F.OO=bar") should equal(None)
+      SbtDotenv.isValidLine("F.OO=bar") should equal(true)
+      SbtDotenv.parseLine("F.OO=bar") should equal(Some("F.OO", "bar"))
+
+      SbtDotenv.isValidLine("F/OO=bar") should equal(false)
+      SbtDotenv.parseLine("F/OO=bar") should equal(None)
 
       SbtDotenv.isValidLine("1234=5678") should equal(false)
       SbtDotenv.parseLine("1234=5678") should equal(None)


### PR DESCRIPTION
The `.` character can be used, for example to specify list elements with
the [lightbend/config](https://github.com/lightbend/config) library.

Changed the previous "F.OO" test to successfully match the validLine patttern
and added another test with an invalid '/' character.

Closes #23.