### PR TITLE
greater support for shell-like .env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,31 @@ Create a .env file in the root of your project with some environment specific se
 vi .env
 
 ```
-MONGO_PORT=17017
-WHO=you
-I_BLOW_MY_NOSE=At $WHO
+# this is an example .env file, comments like this will be ignored
+URL_HOST=my-service.example.org # trailing comments are ignored too!
+
+# you can export variables like a regular shell script
+export URL_PORT=1234
+
+# variables can be quoted
+URL_PATH="/my-content#body"
+
+# variable expansion is supported
+URL=http://$SERVICE_HOST:${SERVICE_PORT}${URL_PATH}
+
+# these will work with sbt-dotenv, but won't work with `source .env`
+MY.VARIABLE=1
+MY-OTHER-VARIABLE=2
+
+# multiline variables work too
+MY_CERT="-----BEGIN CERTIFICATE-----
+123456789qwertyuiopasdfghjklzxcvbnm
+-----END CERTIFICATE-----
+"
+
+# heredocs aren't supported!
 ```
 
-Variable expansion of the form `$FOO` and `${FOO}` is supported based on the values in `.env` or the system environment.
 
 ## Should I commit my .env file?
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ MY_CERT="-----BEGIN CERTIFICATE-----
 # heredocs aren't supported!
 ```
 
+Variable expansion of the form `$FOO` and `${FOO}` is supported based on the values in `.env` or the system environment.
 
 ## Should I commit my .env file?
 

--- a/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
+++ b/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
@@ -91,6 +91,7 @@ object SbtDotenv extends AutoPlugin {
   private val LINE_REGEX =
     """(?x)
        (?:^|\A)                  # start of line
+       \s*                       # leading whitespace
        ([a-zA-Z_]+[a-zA-Z0-9_]*) # variable name
        (?:\s*=\s*?)              # assignment with whitespace
        (.*)                      # variable value

--- a/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
+++ b/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
@@ -88,7 +88,7 @@ object SbtDotenv extends AutoPlugin {
     }
   }
 
-  def isValidLine(line: String): Boolean = line.matches("^[a-zA-Z_]+[a-zA-Z0-9_]*=.*")
+  private def isValidLine(line: String): Boolean = line.matches("^[a-zA-Z_]+[a-zA-Z0-9_]*=.*")
 
   /**
    * Extract k/v pairs from each line as an environment Key -> Value.

--- a/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
+++ b/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
@@ -103,7 +103,7 @@ object SbtDotenv extends AutoPlugin {
          |                  # or
          "(?:\\"|[^"])*"    # double quoted variable
          |                  # or
-         [^\#\r\n]+         # unquoted variable
+         [^\#\r\n]*         # unquoted variable
        )                  # end variable value (captured)
        \s*                # trailing whitespace
        (?:                # start trailing comment (optional)

--- a/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
+++ b/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
@@ -90,11 +90,11 @@ object SbtDotenv extends AutoPlugin {
 
   private val LINE_REGEX =
     """(?x)
-       ^                         # start of line
+       (?:^|\A)                  # start of line
        ([a-zA-Z_]+[a-zA-Z0-9_]*) # variable name
-       =                         # assignment
+       (?:\s*=\s*?)              # assignment with whitespace
        (.*)                      # variable value
-       $                         # end of line
+       (?:$|\z)                  # end of line
     """.r
 
   /**

--- a/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
+++ b/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
@@ -88,7 +88,14 @@ object SbtDotenv extends AutoPlugin {
     }
   }
 
-  private def isValidLine(line: String): Boolean = line.matches("^[a-zA-Z_]+[a-zA-Z0-9_]*=.*")
+  private val LINE_REGEX =
+    """(?x)
+       ^                         # start of line
+       ([a-zA-Z_]+[a-zA-Z0-9_]*) # variable name
+       =                         # assignment
+       (.*)                      # variable value
+       $                         # end of line
+    """.r
 
   /**
    * Extract k/v pairs from each line as an environment Key -> Value.
@@ -97,11 +104,11 @@ object SbtDotenv extends AutoPlugin {
    * @return
    */
   def parseLine(line: String): Option[(String, String)] = {
-    if (isValidLine(line)) {
-      val splitted = line.split("=", 2)
-      Some(splitted(0) -> splitted(1).split(" #")(0).trim)
-    } else {
-      None
+    line match {
+      case LINE_REGEX(key, value) =>
+        Some(key -> value.split(" #")(0).trim)
+      case _ =>
+        None
     }
   }
 }

--- a/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
+++ b/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
@@ -92,6 +92,7 @@ object SbtDotenv extends AutoPlugin {
     """(?x)
        (?:^|\A)                  # start of line
        \s*                       # leading whitespace
+       (?:export\s+)?            # export (optional)
        ([a-zA-Z_]+[a-zA-Z0-9_]*) # variable name (captured)
        (?:\s*=\s*?)              # assignment with whitespace
        (                         # start variable value (captured)

--- a/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
+++ b/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
@@ -90,24 +90,27 @@ object SbtDotenv extends AutoPlugin {
 
   private val LINE_REGEX =
     """(?xms)
-       (?:^|\A)                  # start of line
-       \s*                       # leading whitespace
-       (?:export\s+)?            # export (optional)
-       ([a-zA-Z_]+[a-zA-Z0-9_]*) # variable name (captured)
-       (?:\s*=\s*?)              # assignment with whitespace
-       (                         # start variable value (captured)
-         '(?:\\'|[^'])*'           # single quoted variable
-         |                         # or
-         "(?:\\"|[^"])*"           # double quoted variable
-         |                         # or
-         [^\#\r\n]+                # unquoted variable
-       )                         # end variable value (captured)
-       \s*                       # trailing whitespace
-       (?:                       # start trailing comment (optional)
-         \#                        # begin comment
-         (?:(?!$).)*               # any character up to end-of-line
-       )?                        # end trailing comment (optional)
-       (?:$|\z)                  # end of line
+       (?:^|\A)           # start of line
+       \s*                # leading whitespace
+       (?:export\s+)?     # export (optional)
+       (                  # start variable name (captured)
+         [a-zA-Z_]          # single alphabetic or underscore character
+         [a-zA-Z0-9_.-]*    # zero or more alphnumeric, underscore, period or hyphen
+       )                  # end variable name (captured)
+       (?:\s*=\s*?)       # assignment with whitespace
+       (                  # start variable value (captured)
+         '(?:\\'|[^'])*'    # single quoted variable
+         |                  # or
+         "(?:\\"|[^"])*"    # double quoted variable
+         |                  # or
+         [^\#\r\n]+         # unquoted variable
+       )                  # end variable value (captured)
+       \s*                # trailing whitespace
+       (?:                # start trailing comment (optional)
+         \#                 # begin comment
+         (?:(?!$).)*        # any character up to end-of-line
+       )?                 # end trailing comment (optional)
+       (?:$|\z)           # end of line
     """.r
 
   def parse(source: Source): Map[String, String] = parse(source.mkString)

--- a/src/sbt-test/sbt-dotenv/check-special-cases/.env
+++ b/src/sbt-test/sbt-dotenv/check-special-cases/.env
@@ -3,4 +3,4 @@ LINE_TWO=abc=def
 LINE_THREE=xyz #xyz
 LINE_FOUR=a b c
 LINE_FIVE='xyz'
-LINE_SIX=abc#xyz
+LINE_SIX="abc#xyz"

--- a/src/sbt-test/sbt-dotenv/check-special-cases/build.sbt
+++ b/src/sbt-test/sbt-dotenv/check-special-cases/build.sbt
@@ -1,13 +1,30 @@
 version := "0.1"
 
 TaskKey[Unit]("check") :=  {
+  val log = sLog.value
   val lastLog: File = BuiltinCommands.lastLogFile(state.value).get
   val last: String = IO.read(lastLog)
-  val contains = last.contains("Configured .env environment")
-  if (!contains)
-    sys.error("expected log message")
-  if (!(sys.env.get("LINE_ONE").exists(_ == "") && sys.env.get("LINE_TWO").exists(_ == "abc=def") &&
-    sys.env.get("LINE_THREE").exists(_ == "xyz") && sys.env.get("LINE_FOUR").exists(_ == "a b c") &&
-    sys.env.get("LINE_FIVE").exists(_ == "'xyz'" && sys.env.get("LINE_SIX").exists(_ == "abc#xyz"))))
-    sys.error("environment variables have unexpected values")
+  val expected = "Configured .env environment"
+
+  log.info(s"checking for $expected in log output:\n$last")
+  if (!last.contains(expected)) {
+    sys.error(s"couldn't find $expected in log output")
+  }
+
+  def checkEnv(name: String, expected: String): Unit = {
+    val actual = sys.env(name)
+    log.info(s"""checking that $$$name is equal to $expected""")
+    if (actual.contains(expected)) {
+      log.debug(s"""$$$name, value $actual == $expected""")
+    } else {
+      sys.error(s"""sys.env("$name") $actual != $expected""")
+    }
+  }
+
+  checkEnv("LINE_ONE", "")
+  checkEnv("LINE_TWO", "abc=def")
+  checkEnv("LINE_THREE", "xyz")
+  checkEnv("LINE_FOUR", "a b c")
+  checkEnv("LINE_FIVE", "xyz")
+  checkEnv("LINE_SIX", "abc#xyz")
 }

--- a/src/test/resources/.dotenv.valid
+++ b/src/test/resources/.dotenv.valid
@@ -1,4 +1,5 @@
 # this is a valid .env file
+EMPTY_VARIABLE=
 export COVERALLS_REPO_TOKEN=aoeucaPDc2rvkFugUGlNaCGu3EOeoaeu63WLo5 # some token
 MONGO_PORT=17017
 MONGO_URL="http://localhost:$MONGO_PORT/mongo#asdf"

--- a/src/test/resources/.dotenv.valid
+++ b/src/test/resources/.dotenv.valid
@@ -1,2 +1,4 @@
-COVERALLS_REPO_TOKEN=aoeucaPDc2rvkFugUGlNaCGu3EOeoaeu63WLo5
+# this is a valid .env file
+export COVERALLS_REPO_TOKEN=aoeucaPDc2rvkFugUGlNaCGu3EOeoaeu63WLo5 # some token
 MONGO_PORT=17017
+MONGO_URL="http://localhost:$MONGO_PORT/mongo#asdf"

--- a/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
+++ b/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
@@ -76,6 +76,10 @@ class SbtDotenvSpec extends WordSpec with Matchers {
       SbtDotenv.parseLine("FOO   =   boo") should equal(Some("FOO", "boo"))
     }
 
+    "accept lines with leading whitespace before variable name" in {
+      SbtDotenv.parseLine("   FOO=noo") should equal(Some("FOO", "noo"))
+    }
+
     "validate correct lines in a .env file" in {
       SbtDotenv.parseLine("FOO=bar") should equal(Some("FOO", "bar"))
 

--- a/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
+++ b/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
@@ -72,6 +72,10 @@ class SbtDotenvSpec extends WordSpec with Matchers {
       SbtDotenv.parseLine("FOO='a=b==ccddd'") should equal(Some("FOO", "'a=b==ccddd'"))
     }
 
+    "accept lines with whitespace around assignment operator" in {
+      SbtDotenv.parseLine("FOO   =   boo") should equal(Some("FOO", "boo"))
+    }
+
     "validate correct lines in a .env file" in {
       SbtDotenv.parseLine("FOO=bar") should equal(Some("FOO", "bar"))
 

--- a/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
+++ b/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
@@ -40,6 +40,7 @@ class SbtDotenvSpec extends WordSpec with Matchers {
       val file = new File("./src/test/resources/.dotenv.valid")
 
       SbtDotenv.parseFile(file) should equal(Some(Map(
+        "EMPTY_VARIABLE" -> "",
         "MONGO_PORT" -> "17017",
         "COVERALLS_REPO_TOKEN" -> "aoeucaPDc2rvkFugUGlNaCGu3EOeoaeu63WLo5",
         "MONGO_URL" -> "http://localhost:$MONGO_PORT/mongo#asdf"
@@ -56,6 +57,10 @@ class SbtDotenvSpec extends WordSpec with Matchers {
 
     "not accept lines with no assignment" in {
       SbtDotenv.parse("F") should equal(Map())
+    }
+
+    "accept empty variables" in {
+      SbtDotenv.parse("EMPTY=\nONE=TWO") should equal(Map("EMPTY" -> "","ONE" -> "TWO"))
     }
 
     "accept unquoted strings containing whitespace" in {

--- a/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
+++ b/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
@@ -65,15 +65,20 @@ class SbtDotenvSpec extends WordSpec with Matchers {
     }
 
     "accept lines with URLs containing # characters" in {
-      SbtDotenv.parseLine("WITH_HASH_URL=http://example.com#awesome-id") should equal(Some("WITH_HASH_URL", "http://example.com#awesome-id"))
+      SbtDotenv.parseLine("WITH_HASH_URL='http://example.com#awesome-id'") should equal(Some("WITH_HASH_URL", "http://example.com#awesome-id"))
     }
 
-    "accept lines with quoted variables" in {
-      SbtDotenv.parseLine("FOO='a=b==ccddd'") should equal(Some("FOO", "'a=b==ccddd'"))
+    "accept lines with quoted variables and strips quotes" in {
+      SbtDotenv.parseLine("FOO='a=b==ccddd'") should equal(Some("FOO", "a=b==ccddd"))
+      SbtDotenv.parseLine("FOO=\"blah # blah \r blah \n blah \"") should equal(Some("FOO", "blah # blah \r blah \n blah "))
     }
 
     "accept lines with whitespace around assignment operator" in {
       SbtDotenv.parseLine("FOO   =   boo") should equal(Some("FOO", "boo"))
+    }
+
+    "accept lines with escaped characters and unescape them" in {
+      SbtDotenv.parseLine("FOO=' \\\' \\\' '") should equal(Some("FOO", " \' \' "))
     }
 
     "accept lines with leading whitespace before variable name" in {

--- a/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
+++ b/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
@@ -85,6 +85,10 @@ class SbtDotenvSpec extends WordSpec with Matchers {
       SbtDotenv.parseLine("   FOO=noo") should equal(Some("FOO", "noo"))
     }
 
+    "accept lines with leading export and ignore the export" in {
+      SbtDotenv.parseLine(" export FOO=noo") should equal(Some("FOO", "noo"))
+    }
+
     "validate correct lines in a .env file" in {
       SbtDotenv.parseLine("FOO=bar") should equal(Some("FOO", "bar"))
 

--- a/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
+++ b/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
@@ -44,6 +44,41 @@ class SbtDotenvSpec extends WordSpec with Matchers {
       map.get("COVERALLS_REPO_TOKEN") should equal("aoeucaPDc2rvkFugUGlNaCGu3EOeoaeu63WLo5")
     }
 
+    "not accept empty lines" in {
+      SbtDotenv.isValidLine("") should equal(false)
+      SbtDotenv.parseLine("") should equal(None)
+    }
+
+    "not accept numeric variable names" in {
+      SbtDotenv.isValidLine("1234=5678") should equal(false)
+      SbtDotenv.parseLine("1234=5678") should equal(None)
+    }
+
+    "not accept lines with no assignment" in {
+      SbtDotenv.isValidLine("F") should equal(false)
+      SbtDotenv.parseLine("F") should equal(None)
+    }
+
+    "accept unquoted strings containing whitespace" in {
+      SbtDotenv.isValidLine("SOMETHING_TOKEN=I love kittens") should equal(true)
+      SbtDotenv.parseLine("SOMETHING=I love kittens") should equal(Some("SOMETHING", "I love kittens"))
+    }
+
+    "accept lines with trailing comments" in {
+      SbtDotenv.isValidLine("WITHOUT_COMMENT=ThisIsValue # here is a comment") should equal(true)
+      SbtDotenv.parseLine("WITHOUT_COMMENT=ThisIsValue # here is a comment") should equal(Some("WITHOUT_COMMENT", "ThisIsValue"))
+    }
+
+    "accept lines with URLs containing # characters" in {
+      SbtDotenv.isValidLine("WITH_HASH_URL=http://example.com#awesome-id") should equal(true)
+      SbtDotenv.parseLine("WITH_HASH_URL=http://example.com#awesome-id") should equal(Some("WITH_HASH_URL", "http://example.com#awesome-id"))
+    }
+
+    "accept lines with quoted variables" in {
+      SbtDotenv.isValidLine("FOO='a=b==ccddd'") should equal(true)
+      SbtDotenv.parseLine("FOO='a=b==ccddd'") should equal(Some("FOO", "'a=b==ccddd'"))
+    }
+
     "validate correct lines in a .env file" in {
       SbtDotenv.isValidLine("FOO=bar") should equal(true)
       SbtDotenv.parseLine("FOO=bar") should equal(Some("FOO", "bar"))
@@ -54,29 +89,8 @@ class SbtDotenvSpec extends WordSpec with Matchers {
       SbtDotenv.isValidLine("F.OO=bar") should equal(false)
       SbtDotenv.parseLine("F.OO=bar") should equal(None)
 
-      SbtDotenv.isValidLine("1234=5678") should equal(false)
-      SbtDotenv.parseLine("1234=5678") should equal(None)
-
       SbtDotenv.isValidLine("COVERALLS_REPO_TOKEN=NTHnTHSNthnTHSntNt09aoesNTH6") should equal(true)
       SbtDotenv.parseLine("COVERALLS_REPO_TOKEN=NTHnTHSNthnTHSntNt09aoesNTH6") should equal(Some("COVERALLS_REPO_TOKEN", "NTHnTHSNthnTHSntNt09aoesNTH6"))
-
-      SbtDotenv.isValidLine("SOMETHING_TOKEN=I love kittens") should equal(true)
-      SbtDotenv.parseLine("SOMETHING=I love kittens") should equal(Some("SOMETHING", "I love kittens"))
-
-      SbtDotenv.isValidLine("FOO='a=b==ccddd'") should equal(true)
-      SbtDotenv.parseLine("FOO='a=b==ccddd'") should equal(Some("FOO", "'a=b==ccddd'"))
-
-      SbtDotenv.isValidLine("F") should equal(false)
-      SbtDotenv.parseLine("F") should equal(None)
-
-      SbtDotenv.isValidLine("") should equal(false)
-      SbtDotenv.parseLine("") should equal(None)
-
-      SbtDotenv.isValidLine("WITHOUT_COMMENT=ThisIsValue # here is a comment") should equal(true)
-      SbtDotenv.parseLine("WITHOUT_COMMENT=ThisIsValue # here is a comment") should equal(Some("WITHOUT_COMMENT", "ThisIsValue"))
-
-      SbtDotenv.isValidLine("WITH_HASH_URL=http://example.com#awesome-id") should equal(true)
-      SbtDotenv.parseLine("WITH_HASH_URL=http://example.com#awesome-id") should equal(Some("WITH_HASH_URL", "http://example.com#awesome-id"))
     }
   }
 }

--- a/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
+++ b/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
@@ -91,6 +91,12 @@ class SbtDotenvSpec extends WordSpec with Matchers {
       SbtDotenv.parse(" export FOO=noo") should equal(Map("FOO" -> "noo"))
     }
 
+    "accept lines with variables containing undescores, periods, and hyphens" in {
+      SbtDotenv.parse(" export F.OO=period") should equal(Map("F.OO" -> "period"))
+      SbtDotenv.parse("FO-O=hyphen") should equal(Map("FO-O" -> "hyphen"))
+      SbtDotenv.parse("FOO__ = underscore") should equal(Map("FOO__" -> "underscore"))
+    }
+
     "accept multi-line variables" in {
       val content = """MY_CERT="-----BEGIN CERTIFICATE-----
         |123456789qwertyuiopasdfghjklzxcvbnm
@@ -107,8 +113,6 @@ class SbtDotenvSpec extends WordSpec with Matchers {
       SbtDotenv.parse("FOO=bar") should equal(Map("FOO" -> "bar"))
 
       SbtDotenv.parse("FOO=1234") should equal(Map("FOO" -> "1234"))
-
-      SbtDotenv.parse("F.OO=bar") should equal(Map())
 
       SbtDotenv.parse("COVERALLS_REPO_TOKEN=NTHnTHSNthnTHSntNt09aoesNTH6") should equal(Map("COVERALLS_REPO_TOKEN" -> "NTHnTHSNthnTHSntNt09aoesNTH6"))
     }

--- a/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
+++ b/src/test/scala/au/com/onegeek/sbtdotenv/SbtDotenvSpec.scala
@@ -45,51 +45,40 @@ class SbtDotenvSpec extends WordSpec with Matchers {
     }
 
     "not accept empty lines" in {
-      SbtDotenv.isValidLine("") should equal(false)
       SbtDotenv.parseLine("") should equal(None)
     }
 
     "not accept numeric variable names" in {
-      SbtDotenv.isValidLine("1234=5678") should equal(false)
       SbtDotenv.parseLine("1234=5678") should equal(None)
     }
 
     "not accept lines with no assignment" in {
-      SbtDotenv.isValidLine("F") should equal(false)
       SbtDotenv.parseLine("F") should equal(None)
     }
 
     "accept unquoted strings containing whitespace" in {
-      SbtDotenv.isValidLine("SOMETHING_TOKEN=I love kittens") should equal(true)
       SbtDotenv.parseLine("SOMETHING=I love kittens") should equal(Some("SOMETHING", "I love kittens"))
     }
 
     "accept lines with trailing comments" in {
-      SbtDotenv.isValidLine("WITHOUT_COMMENT=ThisIsValue # here is a comment") should equal(true)
       SbtDotenv.parseLine("WITHOUT_COMMENT=ThisIsValue # here is a comment") should equal(Some("WITHOUT_COMMENT", "ThisIsValue"))
     }
 
     "accept lines with URLs containing # characters" in {
-      SbtDotenv.isValidLine("WITH_HASH_URL=http://example.com#awesome-id") should equal(true)
       SbtDotenv.parseLine("WITH_HASH_URL=http://example.com#awesome-id") should equal(Some("WITH_HASH_URL", "http://example.com#awesome-id"))
     }
 
     "accept lines with quoted variables" in {
-      SbtDotenv.isValidLine("FOO='a=b==ccddd'") should equal(true)
       SbtDotenv.parseLine("FOO='a=b==ccddd'") should equal(Some("FOO", "'a=b==ccddd'"))
     }
 
     "validate correct lines in a .env file" in {
-      SbtDotenv.isValidLine("FOO=bar") should equal(true)
       SbtDotenv.parseLine("FOO=bar") should equal(Some("FOO", "bar"))
 
-      SbtDotenv.isValidLine("FOO=1234") should equal(true)
       SbtDotenv.parseLine("FOO=1234") should equal(Some("FOO", "1234"))
 
-      SbtDotenv.isValidLine("F.OO=bar") should equal(false)
       SbtDotenv.parseLine("F.OO=bar") should equal(None)
 
-      SbtDotenv.isValidLine("COVERALLS_REPO_TOKEN=NTHnTHSNthnTHSntNt09aoesNTH6") should equal(true)
       SbtDotenv.parseLine("COVERALLS_REPO_TOKEN=NTHnTHSNthnTHSntNt09aoesNTH6") should equal(Some("COVERALLS_REPO_TOKEN", "NTHnTHSNthnTHSntNt09aoesNTH6"))
     }
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2-SNAPSHOT"
+version in ThisBuild := "2.0-SNAPSHOT"


### PR DESCRIPTION
Tweak `sbt-dotenv` internals so we handle `.env` files that are more like other dotenv handlers.

In order to make `sbt-dotenv` handle `.env` files I had to make some changes to existing behaviour:
- Variable values containing hash (#) characters now need to be wrapped in quotes so that they aren't judged to be the start of a comment
- Quoted variable names are now de-quoted and any escaped quote characters inside are unescaped

Closes #22 