### PR TITLE
Print new environment map only when debugging

### DIFF
--- a/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
+++ b/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
@@ -81,6 +81,8 @@ object SbtDotenv extends AutoPlugin {
     val dotEnvFile: File = new File(s"${baseDirectory}/${fileName}")
     parseFile(dotEnvFile).map { environment =>
       state.log.info(s".env detected (fileName=${fileName}). About to configure JVM System Environment with new map")
+      // Given the fact that the new environment might have sensitive information, we only print
+      // the new environment when debugging the build.
       state.log.debug(s"New map: $environment")
       VariableExpansion.expandAllVars(sys.env ++ environment, environment)
     }

--- a/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
+++ b/src/main/scala/au/com/onegeek/sbtdotenv/SbtDotenv.scala
@@ -80,7 +80,8 @@ object SbtDotenv extends AutoPlugin {
     state.log.debug(s"looking for .env file: ${baseDirectory}/${fileName}")
     val dotEnvFile: File = new File(s"${baseDirectory}/${fileName}")
     parseFile(dotEnvFile).map { environment =>
-      state.log.info(s".env detected (fileName=${fileName}). About to configure JVM System Environment with new map: $environment")
+      state.log.info(s".env detected (fileName=${fileName}). About to configure JVM System Environment with new map")
+      state.log.debug(s"New map: $environment")
       VariableExpansion.expandAllVars(sys.env ++ environment, environment)
     }
   }


### PR DESCRIPTION
Issue #57 referenced the fact that we're printing the new map at startup.

Considering that the values in the new map might very well contain credentials and would cause a leakage of secrets, I propose that this map be printed only when debugging.