### PR TITLE
Add openjdk11 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
       jdk: openjdk8
     - env: SBT_VERSION=0.13.18
       jdk: openjdk8
+    - env: SBT_VERSION=1.3.12
+      jdk: openjdk11
 
 script:
   - sbt ^^$SBT_VERSION clean test scripted

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ env:
 matrix:
   include:
     - env: SBT_VERSION=1.3.12
-      jdk: oraclejdk8
+      jdk: openjdk8
     - env: SBT_VERSION=0.13.18
-      jdk: oraclejdk8
+      jdk: openjdk8
 
 script:
   - sbt ^^$SBT_VERSION clean test scripted

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 
 matrix:
   include:
-    - env: SBT_VERSION=1.3.8
+    - env: SBT_VERSION=1.3.12
       jdk: oraclejdk8
     - env: SBT_VERSION=0.13.18
       jdk: oraclejdk8

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ IntegrationTest / envFileName := "test.env" // optional
 envVars in IntegrationTest := (envFromFile in IntegrationTest).value
 ```
 
+### "Illegal reflective access" warnings
+
+On java versions 9 and up this plugin will give "illegal reflective access"-warnings. These can be avoided by starting sbt with these extra java options:
+
+```--illegal-access=deny --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED```
 
 ## Should I commit my .env file?
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ It is possible to change the file name `.env`
 envFileName in ThisBuild := "dotenv"
 ```
 
-### Use file to define envifornment for tests
+### Use file to define environment for tests
 It is possible to use same of alternative file to provide an environment for tests:
 ```
 Test / envFileName := "test.env" // optional

--- a/build.sbt
+++ b/build.sbt
@@ -13,9 +13,16 @@ libraryDependencies ++= Seq(
 )
 
 enablePlugins(ScriptedPlugin)
-scriptedLaunchOpts := { scriptedLaunchOpts.value ++
-  Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+
+scriptedLaunchOpts := {
+    if (System.getProperty("java.version").startsWith("1.")) {
+        scriptedLaunchOpts.value ++ Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+    }
+    else {
+        scriptedLaunchOpts.value ++ Seq("--illegal-access=deny", "--add-opens", "java.base/java.util=ALL-UNNAMED", "--add-opens", "java.base/java.lang=ALL-UNNAMED", "-Xmx1024M", "-Dplugin.version=" + version.value)
+    }
 }
+
 scriptedBufferLog := false
 
 publishMavenStyle := false

--- a/src/main/java/au/com/onegeek/sbtdotenv/NativeEnvironmentManager.java
+++ b/src/main/java/au/com/onegeek/sbtdotenv/NativeEnvironmentManager.java
@@ -25,7 +25,7 @@ public abstract class NativeEnvironmentManager {
     static class WindowsNativeEnvironmentManagerImpl extends NativeEnvironmentManager {
         public interface WindowsEnvironmentLibC extends Library {
             WindowsEnvironmentLibC INSTANCE = (
-                (WindowsEnvironmentLibC) Native.loadLibrary("msvcrt",
+                (WindowsEnvironmentLibC) Native.load("msvcrt",
                     WindowsEnvironmentLibC.class)
             );
 
@@ -48,7 +48,7 @@ public abstract class NativeEnvironmentManager {
     static class PosixNativeEnvironmentManagerImpl extends NativeEnvironmentManager {
         public interface PosixEnvironmentLibC extends Library {
             PosixEnvironmentLibC INSTANCE = (
-                (PosixEnvironmentLibC) Native.loadLibrary("c",
+                (PosixEnvironmentLibC) Native.load("c",
                     PosixEnvironmentLibC.class)
             );
 


### PR DESCRIPTION
Applying this PR will switch the travis build to openjdk8 from oraclejdk8 and add openjdk11 to the build matrix. To avoid "illegal reflective access" warnings added extra parameters to the `scriptedLaunchOpts` for java 9 and up. Also added a note on this. Closes #62.